### PR TITLE
Patch 1

### DIFF
--- a/src/KanimExplorer/KanimExplorer.csproj
+++ b/src/KanimExplorer/KanimExplorer.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>KanimExplorer</AssemblyName>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
   <PropertyGroup Condition="'$(CI_VersionPrefix)' != ''">
     <VersionPrefix>$(CI_VersionPrefix)</VersionPrefix>

--- a/src/KanimLib/KanimLib.csproj
+++ b/src/KanimLib/KanimLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/KanimLib/Sprites/Sprite.cs
+++ b/src/KanimLib/Sprites/Sprite.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Drawing;
+using kanimal;
 
 namespace KanimLib.Sprites
 {
@@ -34,8 +35,8 @@ namespace KanimLib.Sprites
 			using (Graphics g = Graphics.FromImage(newImage))
 			{
 				g.Clear(Color.FromArgb(0, 0, 0, 0));
-				g.DrawImage(Image, deltaWidth / 2, deltaHeight / 2, Image.Width, Image.Height);
 			}
+			Image.CopyTo(newImage, deltaWidth / 2, deltaHeight / 2);
 			Image.Dispose();
 			Image = newImage;
 		}

--- a/src/KanimLib/Sprites/SpriteUtils.cs
+++ b/src/KanimLib/Sprites/SpriteUtils.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-
+using kanimal;
 using MaxRectsBinPack;
 
 namespace KanimLib.Sprites
@@ -61,15 +61,12 @@ namespace KanimLib.Sprites
 			PackedSprite[] packedSprites = Pack(sprites, out int atlasWidth, out int atlasHeight);
 
 			Bitmap newAtlas = new Bitmap(atlasWidth, atlasHeight, PixelFormat.Format32bppArgb);
-			using (Graphics g = Graphics.FromImage(newAtlas))
+			foreach (PackedSprite packed in packedSprites)
 			{
-				foreach (PackedSprite packed in packedSprites)
-				{
-					packed.Sprite.FrameData.SetNewSize(packed.BoundingBox, atlasWidth, atlasHeight);
-					g.DrawImage(packed.Sprite.Image, packed.BoundingBox);
-				}
+				packed.Sprite.FrameData.SetNewSize(packed.BoundingBox, atlasWidth, atlasHeight);
+				packed.Sprite.Image.CopyTo(newAtlas, packed.Position.X, packed.Position.Y);
 			}
-
+			
 			return newAtlas;
 		}
 

--- a/src/kanimal/Extensions/BitmapExtensions.cs
+++ b/src/kanimal/Extensions/BitmapExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace kanimal
+{
+    public static class BitmapExtensions
+    {
+        // direct copy pixels bytes to keep color value of transparent pixels
+        public static void CopyTo(this Bitmap src, Bitmap dst, int X, int Y)
+        {
+            var intersect = Rectangle.Intersect(
+                new Rectangle(0, 0, dst.Width, dst.Height),
+                new Rectangle(X, Y, src.Width, src.Height));
+            if (!intersect.IsEmpty)
+            {
+                var src_data = src.LockBits(
+                    new Rectangle(0, 0, src.Width, src.Height),
+                    ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+                int src_bytes_per_line = Math.Abs(src_data.Stride);
+                ReadOnlySpan<byte> src_bytes;
+                unsafe
+                {
+                    src_bytes = new ReadOnlySpan<byte>(src_data.Scan0.ToPointer(), src_bytes_per_line * src_data.Height);
+                }
+
+                var dst_data = dst.LockBits(
+                    new Rectangle(0, 0, dst.Width, dst.Height),
+                    ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
+                int dst_bytes_per_line = Math.Abs(dst_data.Stride);
+                int bytes_per_px = dst_bytes_per_line / dst_data.Width;
+                Span<byte> dst_bytes;
+                unsafe
+                {
+                    dst_bytes = new Span<byte>(dst_data.Scan0.ToPointer(), dst_bytes_per_line * dst_data.Height);
+                }
+
+                int bytes_to_copy = intersect.Width * bytes_per_px;
+                for (int line = 0; line < intersect.Height; line++)
+                {
+                    src_bytes.Slice(((intersect.Y - Y + line) * src.Width + intersect.X - X) * bytes_per_px, bytes_to_copy)
+                        .CopyTo(dst_bytes.Slice(((intersect.Y + line) * dst.Width + intersect.X) * bytes_per_px, bytes_to_copy));
+                }
+                src.UnlockBits(src_data);
+                dst.UnlockBits(dst_data);
+            }
+        }
+    }
+}

--- a/src/kanimal/Reader/ScmlReader.cs
+++ b/src/kanimal/Reader/ScmlReader.cs
@@ -244,6 +244,11 @@ namespace kanimal
             var entity = scml.GetElementsByTagName("entity")[0];
             foreach (var animation in entity.ChildNodes.GetElements())
             {
+                if (animation.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 if (animation.Name != "animation")
                     throw new ProjectParseException(
                         $"SCML format exception: all children of <entity> should be <animation>, but was <{animation.Name}> instead.");
@@ -284,6 +289,11 @@ namespace kanimal
 
             foreach (var anim in animations)
             {
+                if (anim.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 animCount++;
                 if (anim.Name != "animation")
                     throw new ProjectParseException(
@@ -635,6 +645,11 @@ namespace kanimal
                 }
 
                 var anim = (XmlElement) child;
+                if (anim.Name == "character_map")
+                {
+                    Logger.Debug("Skipping <character_map> child of <entity>");
+                    continue;
+                }
                 if (anim.Name != "animation")
                     throw new ProjectParseException(
                         $"SCML format exception: all children of <entity> must be <animation>, was <{anim.Name}> instead.");

--- a/src/kanimal/TexturePacker.cs
+++ b/src/kanimal/TexturePacker.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Linq;
 using NLog;
 using kanimal.MaxRectsBinPack;
@@ -84,12 +85,8 @@ namespace kanimal
                 else
                     sheetW *= 2;
 
-            using (var grD = Graphics.FromImage(SpriteSheet))
-            {
-                foreach (var sprite in SpriteAtlas)
-                    grD.DrawImage(sprite.Sprite,
-                        new Rectangle(sprite.X, sprite.Y, sprite.Width, sprite.Height));
-            }
+            foreach (var sprite in SpriteAtlas)
+                sprite.Sprite.CopyTo(SpriteSheet, sprite.X, sprite.Y);
 
             Logger.Info($"Packed {sheetW} x {sheetH}");
         }
@@ -117,7 +114,7 @@ namespace kanimal
                 SpriteAtlas.Add(new PackedSprite(rect.X, rect.Y, sprite));
             }
 
-            SpriteSheet = new Bitmap(sheet_w, sheet_h);
+            SpriteSheet = new Bitmap(sheet_w, sheet_h, PixelFormat.Format32bppArgb);
 
             return true;
         }

--- a/src/kanimal/kanimal.csproj
+++ b/src/kanimal/kanimal.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="NLog" Version="5.4.0" />


### PR DESCRIPTION
Keep color value of transparent pixels by direct in-memory copy pixels bytes instead of Graphics.DrawImage.
Also sync kanimal, when reading SCML dont throw error if <character_map> entry is present, just ignore it.